### PR TITLE
기능별 권한 제한

### DIFF
--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
@@ -20,8 +20,8 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
-        user.getRoleList().forEach(role -> {
-            authorities.add(() -> role);
+        user.getRoles().forEach(role -> {
+            authorities.add(() -> role.getRole());
         });
 
         return authorities;

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
@@ -72,7 +72,5 @@ public class CustomUserDetails implements UserDetails {
     }
 
     public boolean isDataOwner(String dataOwnerEmail) {
-        log.info(dataOwnerEmail);
-        log.info(getUsername());
         return getUsername().equals(dataOwnerEmail); }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
@@ -2,6 +2,7 @@ package server.sandbox.pinterestclone.auth;
 
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import server.sandbox.pinterestclone.domain.User;
 
@@ -21,7 +22,7 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
         user.getRoles().forEach(role -> {
-            authorities.add(() -> role.getRole());
+            authorities.add(new SimpleGrantedAuthority(role.getRole()));
         });
 
         return authorities;

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/auth/CustomUserDetails.java
@@ -1,30 +1,35 @@
 package server.sandbox.pinterestclone.auth;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import server.sandbox.pinterestclone.domain.User;
+import server.sandbox.pinterestclone.service.enums.UserRole;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 @Getter
+@Slf4j
 public class CustomUserDetails implements UserDetails {
 
     private User user;
 
+    private final Collection<GrantedAuthority> authorities;
+
     public CustomUserDetails(User user) {
         this.user = user;
+        authorities = new ArrayList<>();
+
+        user.getRoles().forEach(role -> {
+            authorities.add(new SimpleGrantedAuthority(role.getRole()));
+        });
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> authorities = new ArrayList<>();
-        user.getRoles().forEach(role -> {
-            authorities.add(new SimpleGrantedAuthority(role.getRole()));
-        });
-
         return authorities;
     }
 
@@ -61,4 +66,13 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public boolean isAdmin() {
+        return this.authorities.contains(new SimpleGrantedAuthority(UserRole.ADMIN.getRole()));
+    }
+
+    public boolean isDataOwner(String dataOwnerEmail) {
+        log.info(dataOwnerEmail);
+        log.info(getUsername());
+        return getUsername().equals(dataOwnerEmail); }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/config/SecurityConfig.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -18,6 +19,7 @@ import server.sandbox.pinterestclone.service.enums.UserRole;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/config/SecurityConfig.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package server.sandbox.pinterestclone.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import server.sandbox.pinterestclone.auth.CustomUserDetailsService;
 import server.sandbox.pinterestclone.filter.JwtAuthFilter;
 import server.sandbox.pinterestclone.jwt.JwtProvider;
+import server.sandbox.pinterestclone.service.enums.UserRole;
 
 @Configuration
 @EnableWebSecurity
@@ -43,6 +45,8 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/user/join", "/user/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/category").hasRole(UserRole.ADMIN.getNonPrefixRole())
+//                        .requestMatchers(HttpMethod.DELETE, "/category").hasRole(UserRole.ADMIN.getNonPrefixRole()) // TODO : 추후 delete 기능 추가 시 활성화.
                         .anyRequest().authenticated());
 
         return http.build();

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/User.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/User.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.sandbox.pinterestclone.domain.converter.RolesAttributeConverter;
+import server.sandbox.pinterestclone.service.enums.UserRole;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +30,8 @@ public class User extends BaseTime {
 
     private String password;
 
-    private String roles;
+    @Convert(converter = RolesAttributeConverter.class)
+    private List<UserRole> roles;
 
     @Builder.Default
     @OneToMany(mappedBy = "user")
@@ -41,13 +44,6 @@ public class User extends BaseTime {
     @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<UserImageHistory> userImageHistories = new ArrayList<>();
-
-    public List<String> getRoleList() {
-        if (this.roles.length() > 0) {
-            return Arrays.asList(this.roles.split(","));
-        }
-        return new ArrayList<>();
-    }
 
     public void addImage(Image image) {
         images.add(image);

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/User.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/User.java
@@ -9,7 +9,6 @@ import server.sandbox.pinterestclone.domain.converter.RolesAttributeConverter;
 import server.sandbox.pinterestclone.service.enums.UserRole;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -54,5 +53,4 @@ public class User extends BaseTime {
     public void addImageHistory(UserImageHistory userImageHistory) {
         userImageHistories.add(userImageHistory);
     }
-
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/converter/RolesAttributeConverter.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/converter/RolesAttributeConverter.java
@@ -19,7 +19,7 @@ public class RolesAttributeConverter implements AttributeConverter<List<UserRole
     }
 
     private UserRole convertRoleStringToUserRoleEnum(String role) {
-        if (UserRole.ADMIN.getRole() == role) return UserRole.ADMIN;
-        else  return UserRole.USER;
+        if (UserRole.ADMIN.getRole().equals(role)) return UserRole.ADMIN;
+        else return UserRole.USER;
     }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/converter/RolesAttributeConverter.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/converter/RolesAttributeConverter.java
@@ -1,0 +1,25 @@
+package server.sandbox.pinterestclone.domain.converter;
+
+import jakarta.persistence.AttributeConverter;
+import server.sandbox.pinterestclone.service.enums.UserRole;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RolesAttributeConverter implements AttributeConverter<List<UserRole>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<UserRole> roles) {
+        return roles.stream().map(role -> role.getRole()).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public List<UserRole> convertToEntityAttribute(String roles) {
+        return Arrays.asList(roles.split(", ")).stream().map(role -> convertRoleStringToUserRoleEnum(role)).toList();
+    }
+
+    private UserRole convertRoleStringToUserRoleEnum(String role) {
+        if (UserRole.ADMIN.getRole() == role) return UserRole.ADMIN;
+        else  return UserRole.USER;
+    }
+}

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/ImageMetaRequest.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/ImageMetaRequest.java
@@ -10,7 +10,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ImageMetaRequest {
-    int userId;
     String title;
     String content;
     String key;

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/ImageReplyRequest.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/ImageReplyRequest.java
@@ -9,6 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ImageReplyRequest {
     int imageMetaId;
-    int userId;
     String content;
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/SaveImageRequest.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/domain/dto/SaveImageRequest.java
@@ -8,6 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SaveImageRequest {
-    int userId;
     int imageMetaId;
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/ImageReplyRepository.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/ImageReplyRepository.java
@@ -2,6 +2,8 @@ package server.sandbox.pinterestclone.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 import server.sandbox.pinterestclone.domain.ImageReply;
 
@@ -19,7 +21,8 @@ public class ImageReplyRepository {
         return em.find(ImageReply.class, id);
     }
 
-    public void deleteReply(ImageReply reply) {
+    @PreAuthorize("isAuthenticated() and (principal.isDataOwner(#imageReplyCreatorEmail) or principal.isAdmin())")
+    public void deleteReply(ImageReply reply, @P("imageReplyCreatorEmail") String imageReplyCreatorEmail) {
         em.remove(reply);
     }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/ImageRepository.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/ImageRepository.java
@@ -3,6 +3,8 @@ package server.sandbox.pinterestclone.repository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 import server.sandbox.pinterestclone.domain.Image;
 import server.sandbox.pinterestclone.domain.ImageCategory;
@@ -29,7 +31,8 @@ public class ImageRepository {
         return em.find(Image.class, id);
     }
 
-    public void deleteImage(Image image) {
+    @PreAuthorize("isAuthenticated() and (principal.isDataOwner(#imageCreatorEmail) or principal.isAdmin())")
+    public void deleteImage(Image image, @P("imageCreatorEmail") String imageCreatorEmail) {
         em.remove(image);
     }
 

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/SaveImageRepository.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/repository/SaveImageRepository.java
@@ -2,6 +2,8 @@ package server.sandbox.pinterestclone.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 import server.sandbox.pinterestclone.domain.Image;
 import server.sandbox.pinterestclone.domain.SaveImage;
@@ -30,7 +32,8 @@ public class SaveImageRepository {
                 .getSingleResult();
     }
 
-    public void deleteSaveImage(int id) {
+    @PreAuthorize("isAuthenticated() and (principal.isDataOwner(#saveImageCreatorEmail) or principal.isAdmin())")
+    public void deleteSaveImage(int id, @P("saveImageCreatorEmail") String saveImageCreatorEmail) {
         em.createQuery("delete from SaveImage si where si.id = :id")
                 .setParameter("id", id)
                 .executeUpdate();

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageReplyService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageReplyService.java
@@ -1,6 +1,7 @@
 package server.sandbox.pinterestclone.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -25,7 +26,8 @@ public class ImageReplyService {
     private final ImageRepository imageRepository;
 
     public int addReply(ImageReplyRequest imageReplyRequest) {
-        User user = userRepository.findById(imageReplyRequest.getUserId());
+        String userEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findUserByEmail(userEmail);
         Image image = imageRepository.findById(imageReplyRequest.getImageMetaId());
 
         validateUser(user);

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageReplyService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageReplyService.java
@@ -40,7 +40,7 @@ public class ImageReplyService {
         ImageReply imageReply = imageReplyRepository.findById(id);
         isExistReply(imageReply);
 
-        imageReplyRepository.deleteReply(imageReply);
+        imageReplyRepository.deleteReply(imageReply, imageReply.getUser().getEmail());
 
         return id;
     }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageService.java
@@ -2,6 +2,7 @@ package server.sandbox.pinterestclone.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -44,7 +45,8 @@ public class ImageService {
 
     @Transactional
     public Integer addImage(ImageMetaRequest imageMetaRequest) {
-        User user = userRepository.findById(imageMetaRequest.getUserId());
+        String userEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findUserByEmail(userEmail);
         validateUser(user);
         imageMetaRequest.getCategoryIds().stream().forEach((categoryId) -> {
             Category category = categoryRepository.findById(categoryId);

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/ImageService.java
@@ -83,7 +83,7 @@ public class ImageService {
 
         deleteS3Image(image);
         deleteSaveImage(image);
-        imageRepository.deleteImage(image);
+        imageRepository.deleteImage(image, image.getUser().getEmail());
 
         return imageId;
     }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/SaveImageService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/SaveImageService.java
@@ -2,6 +2,7 @@ package server.sandbox.pinterestclone.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -27,7 +28,8 @@ public class SaveImageService {
 
     @Transactional
     public int addSaveImage(SaveImageRequest saveImageRequest) {
-        User user = userRepository.findById(saveImageRequest.getUserId());
+        String userEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findUserByEmail(userEmail);
         Image image = imageRepository.findById(saveImageRequest.getImageMetaId());
 
         validateUser(user);

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/SaveImageService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/SaveImageService.java
@@ -46,15 +46,16 @@ public class SaveImageService {
 
     @Transactional
     public int deleteSaveImage(int saveImageId) {
-        isExistSaveImage(saveImageId);
+        SaveImage saveImage = saveImageRepository.findById(saveImageId);
+        isExistSaveImage(saveImage);
         // TODO: save image 조회해서 deleteSaveImage 메서드에 넘기는 방식으로 변경하기.
-        saveImageRepository.deleteSaveImage(saveImageId);
+        saveImageRepository.deleteSaveImage(saveImageId, saveImage.getUser().getEmail());
 
         return saveImageId;
     }
 
-    private void isExistSaveImage(int saveImageId) {
-        if (ObjectUtils.isEmpty(saveImageRepository.findById(saveImageId)))
+    private void isExistSaveImage(SaveImage saveImage) {
+        if (ObjectUtils.isEmpty(saveImage))
             throw new NoSuchElementException(ErrorMessage.NOT_EXIST_SAVE_IMAGE.getMessage());
     }
 

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/UserService.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/UserService.java
@@ -19,7 +19,9 @@ import server.sandbox.pinterestclone.jwt.dto.JwtTokenHeaderForm;
 import server.sandbox.pinterestclone.jwt.dto.UserInfo;
 import server.sandbox.pinterestclone.repository.UserRepository;
 import server.sandbox.pinterestclone.service.enums.ErrorMessage;
+import server.sandbox.pinterestclone.service.enums.UserRole;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -38,7 +40,7 @@ public class UserService {
                 .email(userRequest.getEmail())
                 .name(userRequest.getName())
                 .password(bCryptPasswordEncoder.encode(userRequest.getPassword()))
-                .roles("USER") // TODO : enum 타입 값으로 리팩토링
+                .roles(Arrays.asList(UserRole.USER))
                 .build();
         try {
             userRepository.register(user);

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
@@ -4,5 +4,11 @@ import lombok.Getter;
 
 @Getter
 public enum UserRole {
-    ADMIN, USER;
+    ADMIN("ADMIN"), USER("USER");
+
+    private String role;
+
+    UserRole(String role) {
+        this.role = role;
+    }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
@@ -6,9 +6,14 @@ import lombok.Getter;
 public enum UserRole {
     ADMIN("ADMIN"), USER("USER");
 
+    private String rolePrefix = "ROLE_";
     private String role;
 
     UserRole(String role) {
-        this.role = role;
+        this.role = rolePrefix + role;
+    }
+
+    public String getNonPrefixRole() {
+        return role.replace(rolePrefix, "");
     }
 }

--- a/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
+++ b/pinterest-clone/src/main/java/server/sandbox/pinterestclone/service/enums/UserRole.java
@@ -1,0 +1,8 @@
+package server.sandbox.pinterestclone.service.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    ADMIN, USER;
+}

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageReplyServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageReplyServiceTest.java
@@ -4,13 +4,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
+import server.sandbox.pinterestclone.auth.CustomUserDetails;
+import server.sandbox.pinterestclone.auth.CustomUserDetailsService;
 import server.sandbox.pinterestclone.domain.Image;
-import server.sandbox.pinterestclone.domain.User;
 import server.sandbox.pinterestclone.domain.dto.ImageReplyRequest;
+import server.sandbox.pinterestclone.domain.dto.UserRequest;
 import server.sandbox.pinterestclone.repository.ImageReplyRepository;
 import server.sandbox.pinterestclone.repository.ImageRepository;
-import server.sandbox.pinterestclone.repository.UserRepository;
 
 import java.util.NoSuchElementException;
 
@@ -23,15 +27,19 @@ class ImageReplyServiceTest {
     @Autowired
     private ImageReplyRepository imageReplyRepository;
     @Autowired
-    private UserRepository userRepository;
+    private UserService userService;
     @Autowired
     private ImageRepository imageRepository;
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
 
     @Test
     void addReply() {
-        User user = User.builder()
-                .email("smallj")
-                .name("김지윤")
+        String password = "1234";
+        UserRequest userRequest = UserRequest.builder()
+                .email("smallj@gmail.com")
+                .name("jiyun")
+                .password(password)
                 .build();
 
         Image image = Image.builder()
@@ -41,49 +49,46 @@ class ImageReplyServiceTest {
                 .key("test")
                 .build();
 
-        userRepository.register(user);
+        int userId = userService.register(userRequest);
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         imageRepository.addImage(image);
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), user.getId(), "");
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), "");
         int id = imageReplyService.addReply(imageReplyRequest);
-
         Assertions.assertThat(imageReplyRepository.findById(id)).isNotNull();
-    }
-
-    @Test
-    void checkNotExistUser() {
-        int tempId = 1;
-        Image image = Image.builder()
-                .title("test")
-                .content("test")
-                .url("test")
-                .key("test")
-                .build();
-
-        imageRepository.addImage(image);
-
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), tempId, "");
-        org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> imageReplyService.addReply(imageReplyRequest));
     }
 
     @Test
     void checkNotExistImage() {
         int tempId = 1;
-        User user = User.builder()
-                .email("smallj")
-                .name("김지윤")
+        String password = "1234";
+        UserRequest userRequest = UserRequest.builder()
+                .email("smallj@gmail.com")
+                .name("jiyun")
+                .password(password)
                 .build();
-        userRepository.register(user);
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(tempId, user.getId(), "");
+        int userId = userService.register(userRequest);
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(tempId, "");
         org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> imageReplyService.addReply(imageReplyRequest));
     }
 
     @Test
     void deleteReply() {
-        User user = User.builder()
-                .email("smallj")
-                .name("김지윤")
+        String password = "1234";
+        UserRequest userRequest = UserRequest.builder()
+                .email("smallj@gmail.com")
+                .name("jiyun")
+                .password(password)
                 .build();
 
         Image image = Image.builder()
@@ -93,10 +98,15 @@ class ImageReplyServiceTest {
                 .key("test")
                 .build();
 
-        userRepository.register(user);
+        int userId = userService.register(userRequest);
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         imageRepository.addImage(image);
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), user.getId(), "");
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), "");
         int id = imageReplyService.addReply(imageReplyRequest);
 
         Assertions.assertThat(imageReplyRepository.findById(id)).isNotNull();
@@ -106,9 +116,11 @@ class ImageReplyServiceTest {
 
     @Test
     void deleteNotExistReply() {
-        User user = User.builder()
-                .email("smallj")
-                .name("김지윤")
+        String password = "1234";
+        UserRequest userRequest = UserRequest.builder()
+                .email("smallj@gmail.com")
+                .name("jiyun")
+                .password(password)
                 .build();
 
         Image image = Image.builder()
@@ -118,10 +130,15 @@ class ImageReplyServiceTest {
                 .key("test")
                 .build();
 
-        userRepository.register(user);
+        int userId = userService.register(userRequest);
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         imageRepository.addImage(image);
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), user.getId(), "");
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), "");
         int id = imageReplyService.addReply(imageReplyRequest);
 
         Assertions.assertThat(imageReplyRepository.findById(id)).isNotNull();

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
@@ -231,7 +231,12 @@ class ImageServiceTest {
         Image image = imageRepository.findById(imageId);
         User user = image.getUser();
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), userId2, "");
+        // SecurityContextHolder에 Authentication 객체 담기.
+        customUserDetails = customUserDetailsService.loadUserByUsername(userRequest2.getEmail());
+        authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), "");
         imageReplyService.addReply(imageReplyRequest);
         imageReplyService.addReply(imageReplyRequest);
 
@@ -389,7 +394,12 @@ class ImageServiceTest {
         Image image = imageRepository.findById(imageId);
         User user = image.getUser();
 
-        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), userId2, "");
+        // SecurityContextHolder에 Authentication 객체 담기.
+        customUserDetails = customUserDetailsService.loadUserByUsername(userRequest2.getEmail());
+        authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        ImageReplyRequest imageReplyRequest = new ImageReplyRequest(image.getId(), "");
         imageReplyService.addReply(imageReplyRequest);
         imageReplyService.addReply(imageReplyRequest);
 

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
@@ -165,7 +165,6 @@ class ImageServiceTest {
         ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", ids);
         int id = imageService.addImage(imageMetaRequest);
         Image image = imageRepository.findById(id);
-        saveImageService.addSaveImage(new SaveImageRequest(userId, id));
 
         // TODO: 추후 테스트 방법 찾아보기.
 //        // SecurityContextHolder에 Authentication 객체 담기.
@@ -180,6 +179,7 @@ class ImageServiceTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
+        saveImageService.addSaveImage(new SaveImageRequest(id));
         imageService.deleteImage(id);
         Assertions.assertThat(imageRepository.findById(id)).isNull();
         Assertions.assertThat(imageCategoryRepository.findByImage(image).size()).isEqualTo(0);

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/ImageServiceTest.java
@@ -4,7 +4,12 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
+import server.sandbox.pinterestclone.auth.CustomUserDetails;
+import server.sandbox.pinterestclone.auth.CustomUserDetailsService;
 import server.sandbox.pinterestclone.domain.Category;
 import server.sandbox.pinterestclone.domain.Image;
 import server.sandbox.pinterestclone.domain.User;
@@ -42,6 +47,8 @@ class ImageServiceTest {
     private UserService userService;
     @Autowired
     private ImageReplyService imageReplyService;
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
 
     // TODO : 외부 의존성 포함해서 테스트할 방법 찾기.
 //    @Test
@@ -73,14 +80,19 @@ class ImageServiceTest {
 
     @Test
     void addImage() throws FileNotFoundException, IOException {
+        String password = "1234";
         UserRequest userRequest = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         int userId = userService.register(userRequest);
-        int notExistUserId = 1234;
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -99,17 +111,14 @@ class ImageServiceTest {
 //        byte arr[] = inputStream.readAllBytes();
 //        ImageResponse imageResponse = imageService.uploadImage(new ImageRequest(inputStream, arr.length));
 
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId, "test", "test", "", "", ids);
-        ImageMetaRequest notExistImageMetaRequest = new ImageMetaRequest(notExistUserId, "test", "test", "", "", ids);
-        ImageMetaRequest notExistCategoryImageMetaRequest = new ImageMetaRequest(userId, "test", "test", "", "", notExistCategoryIds);
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", ids);
+        ImageMetaRequest notExistCategoryImageMetaRequest = new ImageMetaRequest("test", "test", "", "", notExistCategoryIds);
 
         int id = imageService.addImage(imageMetaRequest);
         Stream<Category> categories = categoryNames.stream().map(categoryName -> categoryRepository.findByName(categoryName).get(0));
 
         Assertions.assertThat(imageRepository.findById(id)).isNotNull();
         Assertions.assertThat(categories.count()).isEqualTo(categoryNames.size());
-        org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class
-                , () -> imageService.addImage(notExistImageMetaRequest));
         org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class
                 , () -> imageService.addImage(notExistCategoryImageMetaRequest));
     }
@@ -120,13 +129,29 @@ class ImageServiceTest {
     * S3에 실제 이미지 업로드, 삭제 로직은 주석 처리한 후 이 테스트를 실행할 수 있다.
     * */
     void deleteImage() {
+        String password = "1234";
+        UserRequest ownerUserRequest = UserRequest.builder()
+                .email("smallj@gmail.com")
+                .name("jiyun")
+                .password(password)
+                .build();
+
         UserRequest userRequest = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
-        int userId = userService.register(userRequest);
+        UserRequest adminUserRequest = UserRequest.builder()
+                .email("admin@gmail.com")
+                .name("admin")
+                .password(password)
+                .build();
+        // admin 유저에게 어떻게 ADMIN 권한을 부여하지?
+
+        int userId = userService.register(ownerUserRequest);
+        userService.register(userRequest);
+        userService.register(adminUserRequest);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -137,10 +162,23 @@ class ImageServiceTest {
         Stream<CategoryRequest> categoryRequestStream = categoryNames.stream().map(name -> new CategoryRequest(name));
         List<Integer> ids = categoryRequestStream.map(categoryRequest -> categoryService.addCategory(categoryRequest)).toList();
 
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId, "test", "test", "", "", ids);
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", ids);
         int id = imageService.addImage(imageMetaRequest);
         Image image = imageRepository.findById(id);
         saveImageService.addSaveImage(new SaveImageRequest(userId, id));
+
+        // TODO: 추후 테스트 방법 찾아보기.
+//        // SecurityContextHolder에 Authentication 객체 담기.
+//        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+//        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+//        SecurityContextHolder.getContext().setAuthentication(authentication);
+//        org.junit.jupiter.api.Assertions.assertThrows(AccessDeniedException.class
+//                , () -> imageService.deleteImage(id));
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(ownerUserRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         imageService.deleteImage(id);
         Assertions.assertThat(imageRepository.findById(id)).isNull();
@@ -152,20 +190,26 @@ class ImageServiceTest {
 
     @Test
     void findImage() {
+        String password = "1234";
         UserRequest userRequest1 = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         UserRequest userRequest2 = UserRequest.builder()
                 .email("aa@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         int userId1 = userService.register(userRequest1);
         int userId2 = userService.register(userRequest2);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest1.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -176,9 +220,9 @@ class ImageServiceTest {
         Stream<CategoryRequest> categoryRequestStream = categoryNames.stream().map(name -> new CategoryRequest(name));
         List<Integer> categoryIds = categoryRequestStream.map(categoryRequest -> categoryService.addCategory(categoryRequest)).toList();
 
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId1, "test", "test", "", "", categoryIds);
-        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest(userId1, "test", "test", "", "", List.of(categoryIds.get(0)));
-        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest(userId1, "test", "test", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", categoryIds);
+        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest("test", "test", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest("test", "test", "", "", List.of(categoryIds.get(0)));
 
         int imageId = imageService.addImage(imageMetaRequest);
         int similarCategoryImageId1 = imageService.addImage(similarCategoryImageMetaRequest1);
@@ -209,20 +253,26 @@ class ImageServiceTest {
 
     @Test
     void getMainImages() {
+        String password = "1234";
         UserRequest userRequest1 = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         UserRequest userRequest2 = UserRequest.builder()
                 .email("aa@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         int userId1 = userService.register(userRequest1);
         int userId2 = userService.register(userRequest2);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest1.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -234,9 +284,9 @@ class ImageServiceTest {
         List<Integer> categoryIds = categoryRequestStream.map(categoryRequest -> categoryService.addCategory(categoryRequest)).toList();
 
         // 같은 카테고리를 가진 이미지 3개 생성.
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId1, "test", "test", "", "", categoryIds);
-        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest(userId2, "test", "test", "", "", List.of(categoryIds.get(0)));
-        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest(userId2, "test", "test", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", categoryIds);
+        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest("test", "test", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest("test", "test", "", "", List.of(categoryIds.get(0)));
 
         imageService.addImage(imageMetaRequest);
         int similarCategoryImageId1 = imageService.addImage(similarCategoryImageMetaRequest1);
@@ -254,20 +304,26 @@ class ImageServiceTest {
 
     @Test
     void getSearchImages() {
+        String password = "1234";
         UserRequest userRequest1 = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         UserRequest userRequest2 = UserRequest.builder()
                 .email("aa@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         int userId1 = userService.register(userRequest1);
         int userId2 = userService.register(userRequest2);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest1.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -279,9 +335,9 @@ class ImageServiceTest {
         List<Integer> categoryIds = categoryRequestStream.map(categoryRequest -> categoryService.addCategory(categoryRequest)).toList();
 
         // 같은 카테고리를 가진 이미지 3개 생성.
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId1, "test", "test", "", "", categoryIds);
-        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest(userId2, "test", "test", "", "", List.of(categoryIds.get(0)));
-        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest(userId2, "스누피 이미지", "", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", categoryIds);
+        ImageMetaRequest similarCategoryImageMetaRequest1 = new ImageMetaRequest("test", "test", "", "", List.of(categoryIds.get(0)));
+        ImageMetaRequest similarCategoryImageMetaRequest2 = new ImageMetaRequest("스누피 이미지", "", "", "", List.of(categoryIds.get(0)));
 
         imageService.addImage(imageMetaRequest);
         imageService.addImage(similarCategoryImageMetaRequest1);
@@ -298,20 +354,26 @@ class ImageServiceTest {
 
     @Test
     void addUserImageHistory() {
+        String password = "1234";
         UserRequest userRequest1 = UserRequest.builder()
                 .email("smallj@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         UserRequest userRequest2 = UserRequest.builder()
                 .email("aa@gmail.com")
                 .name("jiyun")
-                .password("1234")
+                .password(password)
                 .build();
 
         int userId1 = userService.register(userRequest1);
         int userId2 = userService.register(userRequest2);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest1.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         List<String> categoryNames = new ArrayList<>() {
             {
@@ -322,7 +384,7 @@ class ImageServiceTest {
         Stream<CategoryRequest> categoryRequestStream = categoryNames.stream().map(name -> new CategoryRequest(name));
         List<Integer> categoryIds = categoryRequestStream.map(categoryRequest -> categoryService.addCategory(categoryRequest)).toList();
 
-        ImageMetaRequest imageMetaRequest = new ImageMetaRequest(userId1, "test", "test", "", "", categoryIds);
+        ImageMetaRequest imageMetaRequest = new ImageMetaRequest("test", "test", "", "", categoryIds);
         int imageId = imageService.addImage(imageMetaRequest);
         Image image = imageRepository.findById(imageId);
         User user = image.getUser();

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/SaveImageServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/SaveImageServiceTest.java
@@ -49,29 +49,19 @@ class SaveImageServiceTest {
                 .key("test")
                 .build();
 
-        int temp = userService.register(userRequest);
+        userService.register(userRequest);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         imageRepository.addImage(image);
 
-        SaveImageRequest saveImageRequest = new SaveImageRequest(temp, image.getId());
+        SaveImageRequest saveImageRequest = new SaveImageRequest(image.getId());
         int id = saveImageService.addSaveImage(saveImageRequest);
 
         Assertions.assertThat(saveImageRepository.findById(id)).isNotNull();
-    }
-
-    @Test
-    void checkNotExistUser() {
-        int tempId = 1;
-        Image image = Image.builder()
-                .title("test")
-                .content("test")
-                .url("test")
-                .key("test")
-                .build();
-
-        imageRepository.addImage(image);
-
-        SaveImageRequest saveImageRequest = new SaveImageRequest(tempId, image.getId());
-        org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> saveImageService.addSaveImage(saveImageRequest));
     }
 
     @Test
@@ -84,9 +74,14 @@ class SaveImageServiceTest {
                 .password(password)
                 .build();
 
-        int temp = userService.register(userRequest);
+        userService.register(userRequest);
 
-        SaveImageRequest saveImageRequest = new SaveImageRequest(temp, tempId);
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        SaveImageRequest saveImageRequest = new SaveImageRequest(tempId);
         org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> saveImageService.addSaveImage(saveImageRequest));
     }
 
@@ -106,10 +101,16 @@ class SaveImageServiceTest {
                 .key("test")
                 .build();
 
-        int temp = userService.register(userRequest);
+        userService.register(userRequest);
+
+        // SecurityContextHolder에 Authentication 객체 담기.
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         imageRepository.addImage(image);
 
-        SaveImageRequest saveImageRequest = new SaveImageRequest(temp, image.getId());
+        SaveImageRequest saveImageRequest = new SaveImageRequest(image.getId());
         saveImageService.addSaveImage(saveImageRequest);
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> saveImageService.addSaveImage(saveImageRequest));
     }
@@ -130,7 +131,7 @@ class SaveImageServiceTest {
                 .key("test")
                 .build();
 
-        int temp = userService.register(userRequest);
+        userService.register(userRequest);
 
         // SecurityContextHolder에 Authentication 객체 담기.
         CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
@@ -139,7 +140,7 @@ class SaveImageServiceTest {
 
         imageRepository.addImage(image);
 
-        SaveImageRequest saveImageRequest = new SaveImageRequest(temp, image.getId());
+        SaveImageRequest saveImageRequest = new SaveImageRequest(image.getId());
         int id = saveImageService.addSaveImage(saveImageRequest);
 
         saveImageService.deleteSaveImage(id);
@@ -163,7 +164,7 @@ class SaveImageServiceTest {
                 .key("test")
                 .build();
 
-        int temp = userService.register(userRequest);
+        userService.register(userRequest);
 
         // SecurityContextHolder에 Authentication 객체 담기.
         CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(userRequest.getEmail());
@@ -172,7 +173,7 @@ class SaveImageServiceTest {
 
         imageRepository.addImage(image);
 
-        SaveImageRequest saveImageRequest = new SaveImageRequest(temp, image.getId());
+        SaveImageRequest saveImageRequest = new SaveImageRequest(image.getId());
         int id = saveImageService.addSaveImage(saveImageRequest);
 
         saveImageService.deleteSaveImage(id);

--- a/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/UserServiceTest.java
+++ b/pinterest-clone/src/test/java/server/sandbox/pinterestclone/service/UserServiceTest.java
@@ -15,8 +15,10 @@ import server.sandbox.pinterestclone.domain.dto.UserRequest;
 import server.sandbox.pinterestclone.jwt.dto.JwtTokenHeaderForm;
 import server.sandbox.pinterestclone.repository.ImageRepository;
 import server.sandbox.pinterestclone.repository.UserRepository;
+import server.sandbox.pinterestclone.service.enums.UserRole;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -91,7 +93,7 @@ class UserServiceTest {
                 .email("smallj")
                 .name("김지윤")
                 .password("1234")
-                .roles("USER")
+                .roles(Arrays.asList(UserRole.USER))
                 .build();
 
         List<Image> images = new ArrayList<>();


### PR DESCRIPTION
close #39 
close #38 

- RolesAttributeConverter 를 통해 JPA Entity, DB data 각각에서 사용하는 형태로 role 데이터 치환
- SecurityConfig 클래스에 requestMatcher로 path 별 가져야하는 role 기준 추가
- @PreAuthrize 어노테이션 사용해서 메서드 레벨에서 권한 검사